### PR TITLE
fix problem when verifying a subdomain.

### DIFF
--- a/authenticator.sh
+++ b/authenticator.sh
@@ -27,10 +27,11 @@ if [ -z $DOMAIN ]; then
 fi
 
 # Create TXT record
+NEWHOST=$(python -c "print(('_acme-challenge.'+'$CERTBOT_DOMAIN').replace('.'+'$DOMAIN', ''))")
 RECORD_ID=$(curl -fs 'https://api.name.com/v4/domains/'"$DOMAIN"'/records' \
 	-X POST \
 	-u "$API_USERNAME"':'"$API_TOKEN" \
-	--data '{"host":"_acme-challenge","type":"TXT","answer":"'"$CERTBOT_VALIDATION"'"}' \
+	--data '{"host":"'"$NEWHOST"'","type":"TXT","answer":"'"$CERTBOT_VALIDATION"'"}' \
 		| python -c "import sys,json;print(json.load(sys.stdin)['id'])")
 
 # Save info for cleanup


### PR DESCRIPTION
Example:
DOMAIN=example.com
CERTBOT_DOMAIN=hello.example.com

The TXT record should have host name of "_acme-challenge.hello.example.com" instead of "_acme-challenge.example.com".